### PR TITLE
compatibility to flake based systems

### DIFF
--- a/,
+++ b/,
@@ -6,6 +6,11 @@
 # If there are multiple candidates, the user chooses one using `fzy`.
 set -euo pipefail
 
+dbOutdatedError(){
+  echo "The database used by comma might be outdate. To update it, run:"
+  echo ", --update"
+}
+
 if [[ $# -lt 1 ]]; then
   >&2 echo "usage: , <program> [arguments]"
   exit 1
@@ -14,8 +19,18 @@ fi
 if [[ "$1" == "--install" ]] || [[ "$1" == "-i" ]]; then
   install=1
   shift
+elif [[ "$1" == "--update" ]] || [[ "$1" == "-u" ]]; then
+  ${UPDATE_SCRIPT}
+  exit
 else
   install=""
+fi
+
+# install nix index db
+if [ ! -d "$HOME/.cache/comma/index" ]; then
+  echo "installing default index DB to '$HOME/.cache/comma/index'"
+  mkdir -p "$HOME/.cache/comma/index"
+  cp -r "${NIX_INDEX_DB}" "$HOME/.cache/comma/index"
 fi
 
 argv0=$1; shift
@@ -25,7 +40,7 @@ case "${argv0}" in
     attr="${argv0}"
     ;;
   *)
-    attr="$(nix-locate --db "${NIX_INDEX_DB}" --top-level --minimal --at-root --whole-name "/bin/${argv0}")"
+    attr="$(nix-locate --db "$HOME/.cache/comma/index" --top-level --minimal --at-root --whole-name "/bin/${argv0}")"
     if [[ "$(echo "${attr}" | wc -l)" -ne 1 ]]; then
       attr="$(echo "${attr}" | fzy)"
     fi
@@ -37,8 +52,16 @@ if [[ -z $attr ]]; then
   exit 1
 fi
 
-if [[ -n $install ]]; then
-  nix-env -iA "nixpkgs.${attr%%.*}"
+# on flake based installations nixpkgs is specified via
+# flake input and therefore NIX_PATH might be unset
+if echo $NIX_PATH | grep -q "nixpkgs="; then
+  nixArgs=""
 else
-  nix run "nixpkgs.${attr}" -c "${argv0}" "$@"
+  nixArgs="-I nixpkgs=${NIXPKGS}"
+fi
+
+if [[ -n $install ]]; then
+  nix-env $nixArgs -iA "nixpkgs.${attr%%.*}" || dbOutdatedError
+else
+  nix run $nixArgs "nixpkgs.${attr}" -c "${argv0}" "$@" || dbOutdatedError
 fi

--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,7 @@
 , fzy ? pkgs.fzy
 , makeWrapper ? pkgs.makeWrapper
 , runCommand ? pkgs.runCommand
+, updateScript ? import ./update-index.nix { inherit pkgs; }
 
 # We use this to add matchers for stuff that's not in upstream nixpkgs, but is
 # in our own overlay. No fuzzy matching from multiple options here, it's just:
@@ -50,6 +51,8 @@ stdenv.mkDerivation rec {
     chmod +x $out/bin/,
     wrapProgram $out/bin/, \
       --set NIX_INDEX_DB ${nixIndexDB.out} \
+      --set NIXPKGS ${pkgs.path} \
+      --set UPDATE_SCRIPT ${updateScript} \
       --prefix PATH : ${nix-index.out}/bin \
       --prefix PATH : ${nix.out}/bin \
       --prefix PATH : ${fzy.out}/bin

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1635314702,
+        "narHash": "sha256-/CEuEaXFVl2vQ+o3lYzDPz4lfbHbMebyJqQ4jZ1PT30=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a4bf44345706231f9dd56f85757499af1e940847",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "Comma runs software without installing it";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs, }:
+  let
+    b = builtins;
+    lib = nixpkgs.lib;
+    supportedSystems = [ "x86_64-linux" "x86_64-darwin" ];
+    forAllSystems = f: lib.genAttrs supportedSystems
+      (system: f system (import nixpkgs { inherit system; }));
+  in
+  rec {
+
+    packages = forAllSystems
+      (system: pkgs: {
+        comma = import ./default.nix {
+          inherit pkgs;
+          updateScript = apps."${system}".update-index.program;
+        };
+      });
+
+    defaultPackage = forAllSystems (system: pkgs: packages."${system}".comma);
+
+    apps = forAllSystems
+      (system: pkgs: {
+        update-index = {
+          type = "app";
+          program = b.toString (pkgs.callPackage ./update-index.nix {});
+        };
+      });
+  };
+}

--- a/update-index.nix
+++ b/update-index.nix
@@ -1,0 +1,28 @@
+{
+  pkgs ? import <nixpkgs> {},
+
+  coreutils ? pkgs.coreutils,
+  gnugrep ? pkgs.gnugrep,
+  lib ? pkgs.lib,
+  nix-index ? pkgs.nix-index,
+  writeScript ? pkgs.writeScript,
+}:
+
+writeScript "update-index" ''
+  PATH=${lib.makeBinPath [
+    coreutils
+    gnugrep
+    nix-index
+  ]}
+
+  # on flake based installations nixpkgs is specified via
+  # flake input and therefore NIX_PATH might be unset
+  if echo $NIX_PATH | grep -q "nixpkgs="; then
+    nixpkgs=""
+  else
+    nixpkgs="-I nixpkgs=${pkgs.path}"
+  fi
+
+  mkdir -p $HOME/.cache/comma/
+  nix-index -d $HOME/.cache/comma/index -f $nixpkgs
+''


### PR DESCRIPTION
Problems this tries to solve:
- The project doesn't have a flake.
- Program relies on NIX_PATH which might not exist on flake based systems
- The hard coded index is outdated
- The index cannot be updated without changing the nix expression

Done:
  - add flake.nix
  - use the hardcoded index only as a default, but prefer locally managed index under $HOME/.cache/comma
  - allow user to create and update the local index via `, --update`
  - if a package name from the index could not be found in the local nixpkgs, instruct the user to update the index
  - make all functionality compatible to flakes based systems (not requiring NIX_PATH, but defaulting to NIX_PATH if exists)
  
fixes https://github.com/Shopify/comma/issues/6