### PR TITLE
fix the update script for flakes

### DIFF
--- a/update-index.nix
+++ b/update-index.nix
@@ -17,12 +17,12 @@ writeScript "update-index" ''
 
   # on flake based installations nixpkgs is specified via
   # flake input and therefore NIX_PATH might be unset
-  if echo $NIX_PATH | grep -q "nixpkgs="; then
+  if echo "$NIX_PATH" | grep -q "nixpkgs="; then
     nixpkgs=""
   else
     nixpkgs="-I nixpkgs=${pkgs.path}"
   fi
 
-  mkdir -p $HOME/.cache/comma/
-  nix-index -d $HOME/.cache/comma/index -f $nixpkgs
+  mkdir -p "$HOME/.cache/comma/"
+  nix-index -d "$HOME/.cache/comma/index" -f "$nixpkgs"
 ''

--- a/update-index.nix
+++ b/update-index.nix
@@ -20,7 +20,7 @@ writeScript "update-index" ''
   if echo "$NIX_PATH" | grep -q "nixpkgs="; then
     nixpkgs=""
   else
-    nixpkgs="-I nixpkgs=${pkgs.path}"
+    nixpkgs="${pkgs.path}"
   fi
 
   mkdir -p "$HOME/.cache/comma/"


### PR DESCRIPTION
Not sure if I'm missing something but I had to remove `-I nixpkgs=` in the script, otherwise nix-index would complain.
afaik the -f option only takes the path itself so I'm assuming this was just an oversight?